### PR TITLE
Use pathlib Paths for IO utilities and callers

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+from pathlib import Path
 import logging
 from typing import Optional
 
@@ -164,7 +164,7 @@ class MainWindow(QMainWindow):
         if path:
             self.dm_path.setText(path)
             try:
-                im = imread_gray(path)
+                im = imread_gray(Path(path))
                 self.set_label_image(self.img_dm, im)
                 logger.info("Loaded difference mask from %s", path)
             except Exception as exc:
@@ -176,7 +176,7 @@ class MainWindow(QMainWindow):
         if path:
             self.bm_path.setText(path)
             try:
-                im = imread_gray(path)
+                im = imread_gray(Path(path))
                 self.set_label_image(self.img_bm, im)
                 logger.info("Loaded binary mask from %s", path)
             except Exception as exc:
@@ -194,11 +194,11 @@ class MainWindow(QMainWindow):
             self.out_path.setText(directory)
 
     def start_processing(self) -> None:
-        in_dir = self.in_path.text().strip()
-        out_dir = self.out_path.text().strip()
-        dm = self.dm_path.text().strip()
-        bm = self.bm_path.text().strip()
-        if not (os.path.isdir(in_dir) and os.path.isdir(out_dir) and os.path.isfile(dm) and os.path.isfile(bm)):
+        in_dir = Path(self.in_path.text().strip())
+        out_dir = Path(self.out_path.text().strip())
+        dm = Path(self.dm_path.text().strip())
+        bm = Path(self.bm_path.text().strip())
+        if not (in_dir.is_dir() and out_dir.is_dir() and dm.is_file() and bm.is_file()):
             QMessageBox.warning(self, "Missing Input", "Please provide valid DM, BM, input directory and output directory.")
             logger.warning("Missing input paths: dm=%s bm=%s in=%s out=%s", dm, bm, in_dir, out_dir)
             return

--- a/io_utils.py
+++ b/io_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+from pathlib import Path
 from typing import List
 
 import cv2
@@ -12,12 +12,13 @@ from PyQt6.QtGui import QImage
 logger = logging.getLogger(__name__)
 
 
-def imread_gray(path: str) -> np.ndarray:
+def imread_gray(path: Path | str) -> np.ndarray:
     """Read an image from *path* and ensure it is grayscale."""
-    img = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+    p = Path(path)
+    img = cv2.imread(str(p), cv2.IMREAD_UNCHANGED)
     if img is None:
-        logger.error("Failed to read image: %s", path)
-        raise IOError(f"Failed to read image: {path}")
+        logger.error("Failed to read image: %s", p)
+        raise IOError(f"Failed to read image: {p}")
     if img.ndim == 3:
         img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     return img
@@ -42,14 +43,16 @@ def qimage_from_gray(img: np.ndarray) -> QImage:
     return QImage(g.data, w, h, w, QImage.Format.Format_Grayscale8)
 
 
-def ensure_dir(path: str) -> None:
-    os.makedirs(path, exist_ok=True)
-    logger.debug("Ensured directory exists: %s", path)
+def ensure_dir(path: Path | str) -> None:
+    p = Path(path)
+    p.mkdir(parents=True, exist_ok=True)
+    logger.debug("Ensured directory exists: %s", p)
 
 
-def list_jpgs(folder: str) -> List[str]:
-    files = [f for f in os.listdir(folder) if f.lower().endswith('.jpg')]
-    logger.debug("Found %d .jpg files in %s", len(files), folder)
+def list_jpgs(folder: Path | str) -> List[Path]:
+    p = Path(folder)
+    files = [f for f in p.iterdir() if f.suffix.lower() == '.jpg']
+    logger.debug("Found %d .jpg files in %s", len(files), p)
     return files
 
 
@@ -63,10 +66,11 @@ def num2xlcol(col_num: int) -> str:
     return ''.join(reversed(col_chars))
 
 
-def write_sorted_areas_xlsx(xlsx_path: str, column_index: int, areas: List[int]) -> None:
+def write_sorted_areas_xlsx(xlsx_path: Path | str, column_index: int, areas: List[int]) -> None:
     """Write a list of integer areas into *xlsx_path* at column *column_index* (1‑based)."""
-    if os.path.exists(xlsx_path):
-        wb = load_workbook(xlsx_path)
+    path = Path(xlsx_path)
+    if path.exists():
+        wb = load_workbook(path)
         ws = wb.active
     else:
         wb = Workbook()
@@ -75,4 +79,4 @@ def write_sorted_areas_xlsx(xlsx_path: str, column_index: int, areas: List[int])
     for area in areas:
         ws.cell(row=row, column=column_index, value=int(area))
         row += 1
-    wb.save(xlsx_path)
+    wb.save(path)


### PR DESCRIPTION
## Summary
- Accept `pathlib.Path` objects in io utilities and switch to `Path` methods
- Propagate `Path` usage through worker and GUI modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59f9b5d5483249a7566e981aad3ee