### PR TITLE
Delay diff preview until both top and bottom computed

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -215,7 +215,8 @@ class MainWindow(QMainWindow):
         self.worker.progress.connect(self.progress_bar.setValue)
         self.worker.status.connect(self.statusBar().showMessage)
         self.worker.imagePreviews.connect(self.update_image_previews)
-        self.worker.diffPreviews.connect(self.update_diff_previews)
+        self.worker.topPreview.connect(self.update_top_preview)
+        self.worker.bottomPreview.connect(self.update_bottom_preview)
         self.worker.error.connect(lambda msg: QMessageBox.critical(self, "Error", msg))
         self.worker_thread.start()
 
@@ -234,9 +235,12 @@ class MainWindow(QMainWindow):
         self.set_label_image(self.img_bm, bm)
         self.set_label_image(self.img_input, cur)
 
-    @pyqtSlot(np.ndarray, np.ndarray)
-    def update_diff_previews(self, top: np.ndarray, bottom: np.ndarray) -> None:
+    @pyqtSlot(np.ndarray)
+    def update_top_preview(self, top: np.ndarray) -> None:
         self.set_label_image(self.img_top, top)
+
+    @pyqtSlot(np.ndarray)
+    def update_bottom_preview(self, bottom: np.ndarray) -> None:
         self.set_label_image(self.img_bottom, bottom)
 
     def set_label_image(self, label: QLabel, img: np.ndarray) -> None:

--- a/worker.py
+++ b/worker.py
@@ -75,7 +75,8 @@ class ProcessorWorker(QObject):
     progress = pyqtSignal(int)
     status = pyqtSignal(str)
     imagePreviews = pyqtSignal(np.ndarray, np.ndarray, np.ndarray)
-    diffPreviews = pyqtSignal(np.ndarray, np.ndarray)
+    topPreview = pyqtSignal(np.ndarray)
+    bottomPreview = pyqtSignal(np.ndarray)
     finished = pyqtSignal()
     error = pyqtSignal(str)
 
@@ -195,7 +196,9 @@ class ProcessorWorker(QObject):
                     results_bot[idx] = areas_bot
                     self.status.emit(f"Processing {idx}/{total}: {fname}")
                     self.imagePreviews.emit(dm, bm, cur)
-                    self.diffPreviews.emit(topDiff, botDiff)
+                    # Emit previews only after both diffs are ready
+                    self.topPreview.emit(topDiff)
+                    self.bottomPreview.emit(botDiff)
                     completed += 1
                     progress_pct = int(completed / total * 100)
                     self.progress.emit(progress_pct)


### PR DESCRIPTION
## Summary
- Replace single diffPreviews signal with separate topPreview and bottomPreview signals
- Emit preview signals only after both diffs finish computing to avoid premature updates
- Update GUI connections to use individual preview signals

## Testing
- `python -m py_compile worker.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5a73b3ad48324b27b6bdb23d9f07d