### PR TITLE
Propagate registration mask through processing

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -51,16 +51,30 @@ def _process_file(
     Returns the index, filename, current image, and processing results.
     """
     cur = imread_gray(path)
-    reg = register_ecc(cur, dm, params)
-    binReg_top = cv2.subtract(reg, bm)
-    topDiff = cv2.subtract(clahe_equalize(binDif_top), clahe_equalize(binReg_top))
+    reg, mask = register_ecc(cur, dm, params)
+    reg = reg * mask
+    binDif_top_masked = binDif_top * mask
+    binDif_bot_masked = binDif_bot * mask
+    ys, xs = np.nonzero(mask)
+    if ys.size == 0 or xs.size == 0:
+        empty = np.zeros_like(mask)
+        return idx, path.name, cur, empty, empty, [], []
+    y1, y2 = ys.min(), ys.max() + 1
+    x1, x2 = xs.min(), xs.max() + 1
+    reg = reg[y1:y2, x1:x2]
+    bm_crop = bm[y1:y2, x1:x2]
+    binDif_top_crop = binDif_top_masked[y1:y2, x1:x2]
+    binDif_bot_crop = binDif_bot_masked[y1:y2, x1:x2]
+    binReg_top = cv2.subtract(reg, bm_crop)
+    topDiff = cv2.subtract(clahe_equalize(binDif_top_crop), clahe_equalize(binReg_top))
     cv2.imwrite(str(top_dir / path.name), to_uint8(topDiff))
     topBW = segment_image(topDiff, params)
     cv2.imwrite(str(topbw_dir / path.name), to_uint8(topBW))
     areas_top = connected_component_areas(topBW)
     areas_top.sort(reverse=True)
-    binReg_bot = cv2.subtract(reg, complement(bm))
-    botDiff = cv2.subtract(clahe_equalize(binDif_bot), clahe_equalize(binReg_bot))
+    comp_bm_crop = complement(bm)[y1:y2, x1:x2]
+    binReg_bot = cv2.subtract(reg, comp_bm_crop)
+    botDiff = cv2.subtract(clahe_equalize(binDif_bot_crop), clahe_equalize(binReg_bot))
     cv2.imwrite(str(bot_dir / path.name), to_uint8(botDiff))
     botBW = segment_image(botDiff, params)
     cv2.imwrite(str(botbw_dir / path.name), to_uint8(botBW))


### PR DESCRIPTION
## Summary
- Warp and return a validity mask in `register_ecc`
- Use registration mask to crop images and mask difference calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ab8ce3d88324976cf26715cd8060