### PR TITLE
Add ROI-aware registration and worker processing

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -36,3 +36,17 @@ def test_mask_preparation_dm_bm():
     assert bm.shape == dm.shape
     assert bm.min() >= 0 and bm.max() <= 255
     assert set(np.unique(bm)).issubset({0, 255})
+
+
+def test_registration_with_roi():
+    fixed = load("fixed.pgm")
+    moving = load("moving.pgm")
+    params = RegSegParams(maxIter=50)
+    roi = (2, 2, 10, 10)
+    reg, mask = register_ecc(moving, fixed, params, roi=roi)
+    assert reg.shape == (10, 10)
+    assert mask.shape == (10, 10)
+    assert mask.min() == 1 and mask.max() == 1
+    fixed_roi = fixed[2:12, 2:12]
+    diff = cv2.subtract(fixed_roi, reg)
+    assert diff.max() == 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,48 @@
+import cv2
+import numpy as np
+from pathlib import Path
+
+from worker import _process_file
+from processing import RegSegParams, complement
+
+DATA = Path(__file__).parent / "data"
+
+
+def load(name: str):
+    return cv2.imread(str(DATA / name), cv2.IMREAD_UNCHANGED)
+
+
+def test_process_file_with_roi(tmp_path):
+    fixed = load("fixed.pgm")
+    moving = load("moving.pgm")
+    roi = (2, 2, 10, 10)
+    dm = np.zeros_like(fixed)
+    bm = np.zeros_like(fixed)
+    dm[2:12, 2:12] = fixed[2:12, 2:12]
+    binDif_top = cv2.subtract(dm, bm)
+    binDif_bot = cv2.subtract(dm, complement(bm))
+    img_path = tmp_path / "cur.pgm"
+    cv2.imwrite(str(img_path), moving)
+    top_dir = tmp_path / "top"
+    topbw_dir = tmp_path / "topBW"
+    bot_dir = tmp_path / "bottom"
+    botbw_dir = tmp_path / "bottomBW"
+    for d in (top_dir, topbw_dir, bot_dir, botbw_dir):
+        d.mkdir()
+    params = RegSegParams(maxIter=50)
+    _, _, _, topDiff, botDiff, _, _ = _process_file(
+        1,
+        img_path,
+        dm,
+        bm,
+        params,
+        top_dir,
+        topbw_dir,
+        bot_dir,
+        botbw_dir,
+        binDif_top,
+        binDif_bot,
+        roi,
+    )
+    assert topDiff.shape == (10, 10)
+    assert botDiff.shape == (10, 10)


### PR DESCRIPTION
## Summary
- Allow ProcessorWorker to accept an ROI for DM/BM and pad masks to full image size before processing
- Crop registered images using ROI offsets and pass them through processing pipeline
- Enable `register_ecc` to restrict registration and outputs to an ROI and add tests for ROI-based workflow

## Testing
- `python -m py_compile worker.py processing.py tests/test_processing.py tests/test_worker.py`
- `pip install opencv-python-headless -q` *(fails: Could not find a version that satisfies the requirement)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b5aff9d78c83248a392eb5151b0093