### PR TITLE
Refactor image listing to explicit extension loop

### DIFF
--- a/io_utils.py
+++ b/io_utils.py
@@ -51,9 +51,11 @@ def ensure_dir(path: Path | str) -> None:
 
 def list_jpgs(folder: Path | str) -> List[Path]:
     p = Path(folder)
-    files = sorted(
-        (f.resolve() for f in p.glob("*.{jpg,jpeg,png,tif,tiff}", case_sensitive=False))
-    )
+    exts = ["jpg", "jpeg", "png", "tif", "tiff"]
+    files: List[Path] = []
+    for ext in exts:
+        files.extend(f.resolve() for f in p.glob(f"*.{ext}", case_sensitive=False))
+    files.sort()
     logger.debug("Found %d image files in %s", len(files), p)
     return files
 


### PR DESCRIPTION
## Summary
- Collect image files by looping over specific extensions instead of using brace globs
- Resolve and sort each matched path in `list_jpgs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6104716dc8324aa4e3a9857e3092f