### PR TITLE
Add pytest configuration to restrict test discovery scope

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- Configure pytest to only search for tests in the `tests/` directory

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f6a64b488324a8569a022cea21d7